### PR TITLE
Fix exchangeInfo + add new API fields

### DIFF
--- a/binance4s-rest/src/main/scala/com/deliganli/binance4s/rest/response/filter/SymbolFilter.scala
+++ b/binance4s-rest/src/main/scala/com/deliganli/binance4s/rest/response/filter/SymbolFilter.scala
@@ -212,12 +212,12 @@ object SymbolFilter {
   object MaxNumOrders {
     implicit val d: Decoder[MaxNumOrders] = Decoder.forProduct2(
       "filterType",
-      "limit"
+      "maxNumOrders"
     )(MaxNumOrders.apply)
 
     implicit val e: Encoder[MaxNumOrders] = Encoder.forProduct2(
       "filterType",
-      "limit"
+      "maxNumOrders"
     ) { m =>
       (
         m.filterType,

--- a/binance4s-rest/src/main/scala/com/deliganli/binance4s/rest/response/market/CurrencySymbol.scala
+++ b/binance4s-rest/src/main/scala/com/deliganli/binance4s/rest/response/market/CurrencySymbol.scala
@@ -11,49 +11,58 @@ case class CurrencySymbol(
   baseAssetPrecision: Int,
   quoteAsset: String,
   quotePrecision: Int,
+  quoteAssetPrecision: Int,
   baseCommissionPrecision: Int,
   quoteCommissionPrecision: Int,
   orderTypes: Seq[OrderType],
   icebergAllowed: Boolean,
   ocoAllowed: Boolean,
+  quoteOrderQtyMarketAllowed: Boolean,
   isSpotTradingAllowed: Boolean,
   isMarginTradingAllowed: Boolean,
-  filters: Seq[SymbolFilter])
+  filters: Seq[SymbolFilter],
+  permissions: Seq[Permissions])
 
 object CurrencySymbol {
 
-  implicit val d: Decoder[CurrencySymbol] = Decoder.forProduct14(
+  implicit val d: Decoder[CurrencySymbol] = Decoder.forProduct17(
     "symbol",
     "status",
     "baseAsset",
     "baseAssetPrecision",
     "quoteAsset",
     "quotePrecision",
+    "quoteAssetPrecision",
     "baseCommissionPrecision",
     "quoteCommissionPrecision",
     "orderTypes",
     "icebergAllowed",
     "ocoAllowed",
+    "quoteOrderQtyMarketAllowed",
     "isSpotTradingAllowed",
     "isMarginTradingAllowed",
-    "filters"
+    "filters",
+    "permissions"
   )(CurrencySymbol.apply)
 
-  implicit val e: Encoder[CurrencySymbol] = Encoder.forProduct14(
+  implicit val e: Encoder[CurrencySymbol] = Encoder.forProduct17(
     "symbol",
     "status",
     "baseAsset",
     "baseAssetPrecision",
     "quoteAsset",
     "quotePrecision",
+    "quoteAssetPrecision",
     "baseCommissionPrecision",
     "quoteCommissionPrecision",
     "orderTypes",
     "icebergAllowed",
     "ocoAllowed",
+    "quoteOrderQtyMarketAllowed",
     "isSpotTradingAllowed",
     "isMarginTradingAllowed",
-    "filters"
+    "filters",
+    "permissions"
   ) { m =>
     (
       m.symbol,
@@ -62,14 +71,17 @@ object CurrencySymbol {
       m.baseAssetPrecision,
       m.quoteAsset,
       m.quotePrecision,
+      m.quoteAssetPrecision,
       m.baseCommissionPrecision,
       m.quoteCommissionPrecision,
       m.orderTypes,
       m.icebergAllowed,
       m.ocoAllowed,
+      m.quoteOrderQtyMarketAllowed,
       m.isSpotTradingAllowed,
       m.isMarginTradingAllowed,
-      m.filters
+      m.filters,
+      m.permissions
     )
   }
 }

--- a/binance4s-rest/src/main/scala/com/deliganli/binance4s/rest/response/market/Permissions.scala
+++ b/binance4s-rest/src/main/scala/com/deliganli/binance4s/rest/response/market/Permissions.scala
@@ -1,0 +1,12 @@
+package com.deliganli.binance4s.rest.response.market
+
+import enumeratum._
+
+sealed abstract class Permissions extends EnumEntry
+
+object Permissions extends Enum[Permissions] with CirceEnum[Permissions] {
+  case object SPOT   extends Permissions
+  case object MARGIN extends Permissions
+
+  val values = findValues
+}

--- a/binance4s-rest/src/main/scala/com/deliganli/binance4s/rest/response/market/Permissions.scala
+++ b/binance4s-rest/src/main/scala/com/deliganli/binance4s/rest/response/market/Permissions.scala
@@ -5,8 +5,9 @@ import enumeratum._
 sealed abstract class Permissions extends EnumEntry
 
 object Permissions extends Enum[Permissions] with CirceEnum[Permissions] {
-  case object SPOT   extends Permissions
-  case object MARGIN extends Permissions
+  case object SPOT      extends Permissions
+  case object MARGIN    extends Permissions
+  case object LEVERAGED extends Permissions
 
   val values = findValues
 }

--- a/binance4s-rest/src/test/scala/com/deliganli/binance4s/rest/client/PublicClientTest.scala
+++ b/binance4s-rest/src/test/scala/com/deliganli/binance4s/rest/client/PublicClientTest.scala
@@ -6,6 +6,7 @@ import com.deliganli.binance4s.common.http.JDKHttpClient
 import com.deliganli.binance4s.rest.BinanceRestClient
 import com.deliganli.binance4s.rest.framework.IntegrationTest
 import org.http4s.client.jdkhttpclient.JdkHttpClient
+import com.deliganli.binance4s.rest.response.base.BinanceResponse
 
 class PublicClientTest extends IntegrationTest {
 
@@ -14,56 +15,56 @@ class PublicClientTest extends IntegrationTest {
   )
 
   "ping" should "succeed" in {
-    noException should be thrownBy rest.general.ping.unsafeRunSync()
+    rest.general.ping.unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 
   "time" should "succeed" in {
-    noException should be thrownBy rest.general.time.unsafeRunSync()
+    rest.general.time.unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 
   "exchange info" should "succeed" in {
-    noException should be thrownBy rest.general.exchangeInfo.unsafeRunSync()
+    rest.general.exchangeInfo.unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 
   val symbol = "BTCUSDT"
 
   "avg price" should "succeed" in {
-    noException should be thrownBy rest.market.avgPrice(symbol).unsafeRunSync()
+    rest.market.avgPrice(symbol).unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 
   "depth" should "succeed" in {
-    noException should be thrownBy rest.market.depth(symbol, DepthLimit.Five).unsafeRunSync()
+    rest.market.depth(symbol, DepthLimit.Five).unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 
   "klines" should "succeed" in {
-    noException should be thrownBy rest.market.klines(symbol, KlineInterval.Daily, 5).unsafeRunSync()
+    rest.market.klines(symbol, KlineInterval.Daily, 5).unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 
   "book ticker for single currency" should "succeed" in {
-    noException should be thrownBy rest.market.ticker.bookAll(symbol).unsafeRunSync()
+    rest.market.ticker.bookAll(symbol).unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 
   "book ticker for all" should "succeed" in {
-    noException should be thrownBy rest.market.ticker.book.unsafeRunSync()
+    rest.market.ticker.book.unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 
   "daily ticker for single currency" should "succeed" in {
-    noException should be thrownBy rest.market.ticker.daily(symbol).unsafeRunSync()
+    rest.market.ticker.daily(symbol).unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 
   "daily ticker for all" should "succeed" in {
-    noException should be thrownBy rest.market.ticker.dailyAll.unsafeRunSync()
+    rest.market.ticker.dailyAll.unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 
   "price ticker for single currency" should "succeed" in {
-    noException should be thrownBy rest.market.ticker.price(symbol).unsafeRunSync()
+    rest.market.ticker.price(symbol).unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 
   "price ticker for all" should "succeed" in {
-    noException should be thrownBy rest.market.ticker.priceAll.unsafeRunSync()
+    rest.market.ticker.priceAll.unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 
   "recent trades" should "succeed" in {
-    noException should be thrownBy rest.market.trade.recent(symbol, 1).unsafeRunSync()
+    rest.market.trade.recent(symbol, 1).unsafeRunSync() should matchPattern { case BinanceResponse(_, Right(_), _) => }
   }
 }


### PR DESCRIPTION
Took me a bit of time to figure out the issue...
Mostly the issue was changing to "maxNumOrders" field for MaxNumOrders. 

The change was not documented in the change log as far as I could tell? (cf. https://binance-docs.github.io/apidocs/spot/en/#change-log ), but the returned JSON definitely have the field named maxNumOrders now, and not limit. (btw, which documentation are you looking at when you defined this lib?)

Also, I added the new fields from april/may from the change log.

Also, I made the test checking that the decoding is correct (body is Right), otherwise the JSON conversion are not tested.